### PR TITLE
Mockup (not quite demo) of SQLAlchemy declarative ORM for data tables

### DIFF
--- a/python/tests/test_make_draft_json.py
+++ b/python/tests/test_make_draft_json.py
@@ -1,0 +1,53 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from housinginsights.ingestion.make_draft_json import (sql_name_clean, pandas_to_sql_data_type,
+                                                       make_draft_json, make_all_json)
+
+
+class dataframe_file:
+    columns = ['foo', 'bar']
+
+
+class TestMakeDraftJson(unittest.TestCase):
+    """ Unit tests for ``make_draft_json.py``. """
+
+    def setUp(self):
+        self.name = 'FOO-bar'
+        self.pandas_type_string = 'int64'
+        self.filename = 'test'
+        self.tablename = 'test'
+        self.manifest_path = 'test'
+
+    def test_sql_name_clean(self):
+        result = sql_name_clean(self.name)
+        self.assertEqual(result, 'foo_bar')
+
+    def test_pandas_to_sqal_data_type(self):
+        exists = pandas_to_sql_data_type(self.pandas_type_string)
+        self.assertEqual(exists, 'integer')
+
+        not_exists = pandas_to_sql_data_type('something')
+        self.assertEqual(not_exists, 'text')
+
+    @patch('housinginsights.ingestion.make_draft_json.open')
+    @patch('housinginsights.ingestion.make_draft_json.pandas_to_sql_data_type')
+    @patch('housinginsights.ingestion.make_draft_json.pandas.read_csv')
+    def test_make_draft_json(self, mock_read_csv, mock_pandas_to_sql_data_type, mock_open):
+        """ TODO:  Still needs more tests.
+
+            This is a tricky one to test, there are a lot of external dependencies
+            and global variables that make testing tricky.
+
+            Consider re-factoring this function.
+        """
+        make_draft_json(self.filename, self.tablename)
+        mock_read_csv.assert_called_with(self.filename, encoding='latin1')
+
+    @patch('housinginsights.ingestion.make_draft_json.ManifestReader')
+    def test_make_all_json(self, mock_manifest):
+        """ TODO:  Still needs more tests.
+
+            Need to test with sample Manifest data.
+        """
+        make_all_json(self.manifest_path)
+        mock_manifest.assert_called_with(path=self.manifest_path)


### PR DESCRIPTION
First open source PR here.  Still very much work in progress, but since I saw in mentioned in another post (@jasonrhaas) I figured I'd put it up before the meeting tonight.  I've taken a few tables and turned them into declarative SQLAlchemy classes.  With a bit of luck, this should allow us to have a single representation (in a single file, no less) of the metadata and parsing info for each dataset.  As other people have pointed out, this representation is particularly convenient for writing APIs using flask or flask derivatives.  I'm thinking we could also use the same representation for the data ingestion process, and mixins/Ingestible.py is my vision for how that might work.  Unfortunately, when I try to demonstrate it using a quick sqlite db, I'm getting an error somewhere deep in the ORM, which I'm still trying to track down.  This might not be a problem if someone more knowledgeable could hook this up to the Postgres database (I haven't tried).  Other TODOs include transferring the cleaner code to the relevant classes using the @validates decorator, and putting some code into the Ingestible class to make sure the validations run properly when ingesting from files.  Also coding in the relationships with the crosswalk.

Whether or not we use any of this code, I hope this helps to give everybody a picture of the costs/benefits of the declarative ORM syntax.  See you tonight.